### PR TITLE
Expose kill() function for the handler returned by $os.spawnAsync

### DIFF
--- a/lib/os/BackgroundCommandHandler.js
+++ b/lib/os/BackgroundCommandHandler.js
@@ -165,6 +165,9 @@ class BackgroundCommandHandler {
       running: this.running
     };
   }
+  kill(signal) {
+    return this._handler.kill(signal);
+  }
 }
 
 module.exports = BackgroundCommandHandler;


### PR DESCRIPTION
Also enabled back some tests that were disabled.