### PR TITLE
createTempFile and createTempDir cleanup on SIGINT and uncaughtException

### DIFF
--- a/lib/os/temporary-files.js
+++ b/lib/os/temporary-files.js
@@ -20,6 +20,8 @@ function cleanUp() {
 }
 if (!cleanUpSetup) {
   process.on('exit', cleanUp);
+  process.on('SIGINT', cleanUp);
+  process.on('uncaughtException', function(err) { cleanUp(); console.log(err.stack); });
   cleanUpSetup = true;
 }
 

--- a/lib/os/temporary-files.js
+++ b/lib/os/temporary-files.js
@@ -14,7 +14,7 @@ function cleanUp() {
     try {
       fs.removeSync(f);
     } catch (e) {
-      // Emppty
+      // Empty
     }
   });
 }

--- a/lib/os/temporary-files.js
+++ b/lib/os/temporary-files.js
@@ -21,7 +21,7 @@ function cleanUp() {
 if (!cleanUpSetup) {
   process.on('exit', cleanUp);
   process.on('SIGINT', cleanUp);
-  process.on('uncaughtException', function(err) { cleanUp(); console.log(err.stack); });
+  process.on('uncaughtException', function(err) { cleanUp(); throw err; });
   cleanUpSetup = true;
 }
 

--- a/test/os.js
+++ b/test/os.js
@@ -742,7 +742,7 @@ for i in ${_.range(1, 300).join(' ')}; do sleep 0.01; done
     createTempDir: 'directory'
   }, function(type, fnName) {
     const fnToTest = $os[fnName];
-    describe(`#${fnName}()`, function() {
+    describe.only(`#${fnName}()`, function() {
       let tempFiles = [];
       beforeEach(function() {
         tempFiles = [];
@@ -757,7 +757,7 @@ for i in ${_.range(1, 300).join(' ')}; do sleep 0.01; done
             _.each(tempFiles, f => expect(f).to.not.be.a.path());
           }
         },
-        'Allows marking the temportary paths to not be deleted': {
+        'Allows marking the temporary paths to not be deleted': {
           options: {cleanup: false},
           onExitValidation: function() {
             _.each(tempFiles, f => expect(f).to.be.a[type]());
@@ -765,17 +765,38 @@ for i in ${_.range(1, 300).join(' ')}; do sleep 0.01; done
         }
       }, function(testData, title) {
         it(title, function() {
+          const createSeveralTemp = function createSeveralTemp(times) {
+            _.times(times, function() {
+              const f = fnToTest(testData.options);
+              expect(f).to.be.a[type]();
+              tempFiles.push(f);
+            });
+          };
           const times = 5;
-          _.times(times, function() {
-            const f = fnToTest(testData.options);
-            expect(f).to.be.a[type]();
-            tempFiles.push(f);
-          });
+          createSeveralTemp(times);
           // Check they are unique
           expect(_.uniq(tempFiles).length).to.be.eql(times);
           // Simulate the process exiting
           process.emit('exit');
           testData.onExitValidation();
+
+          createSeveralTemp(times);
+          // Simulate the process receiving SIGINT
+          // Remove the original listener for SIGINT to avoid exit
+          const originalListener = process.listeners('SIGINT').pop();
+          process.removeListener('SIGINT', originalListener);
+          process.emit('SIGINT');
+          process.addListener('SIGINT', originalListener);
+          testData.onExitValidation();
+
+          createSeveralTemp(times);
+          // Simulate the process generating an uncaughtException
+          // Remove mocha listener
+          const mochaListener = process.listeners('uncaughtException').pop();
+          process.removeListener('uncaughtException', mochaListener);
+          try { process.emit('uncaughtException'); } catch (e) { /* Empty */ }
+          testData.onExitValidation();
+          process.addListener('uncaughtException', mochaListener);
         });
       });
     });


### PR DESCRIPTION
Capture not only `exit` but `SIGINT` and `uncaughtException` events too and clean temporal files/folders created.
Test for this new functionality are included in the PR.