### PR TITLE
Support retrieving element in array by index

### DIFF
--- a/lib/file/yaml/get.js
+++ b/lib/file/yaml/get.js
@@ -9,10 +9,10 @@ const read = require('../read.js');
 function _parseKey(key) {
   const result = key.match(/^(.+)\[([0-9]+)\]$/);
 
-  if(result) {
-    return { element: result[1], index: parseInt(result[2], 10) };
+  if (result) {
+    return {element: result[1], index: parseInt(result[2], 10)};
   } else {
-    return { element: key, index: null };
+    return {element: key, index: null};
   }
 }
 

--- a/lib/file/yaml/get.js
+++ b/lib/file/yaml/get.js
@@ -4,6 +4,18 @@ const yaml = require('js-yaml');
 const _ = require('../../lodash-extra.js');
 const read = require('../read.js');
 
+// 'builds[0]' -> { element: builds, index: 0 }
+// 'builds' -> { element: builds, index: null }
+function _parseKey(key) {
+  const result = key.match(/^(.+)\[([0-9\.]+)\]$/);
+
+  if(result) {
+    return { element: result[1], index: parseInt(result[2]) };
+  } else {
+    return { element: key, index: null };
+  }
+}
+
 function _extractValue(data, keyPath) {
   let keyList = [];
 
@@ -24,7 +36,13 @@ function _extractValue(data, keyPath) {
   }
 
   if (keyList.length === 1) {
-    return keyList[0] === '' ? data : data[keyList[0]];
+    const key = _parseKey(keyList[0]);
+
+    if (_.isNumber(key.index)) {
+      return data[key.element][key.index];
+    } else {
+      return key.element === '' ? data : data[key.element];
+    }
   } else {
     const parentKey = keyList.shift();
     if (!_.isString(parentKey)) {

--- a/lib/file/yaml/get.js
+++ b/lib/file/yaml/get.js
@@ -7,10 +7,10 @@ const read = require('../read.js');
 // 'builds[0]' -> { element: builds, index: 0 }
 // 'builds' -> { element: builds, index: null }
 function _parseKey(key) {
-  const result = key.match(/^(.+)\[([0-9\.]+)\]$/);
+  const result = key.match(/^(.+)\[([0-9]+)\]$/);
 
   if(result) {
-    return { element: result[1], index: parseInt(result[2]) };
+    return { element: result[1], index: parseInt(result[2], 10) };
   } else {
     return { element: key, index: null };
   }

--- a/test/file.js
+++ b/test/file.js
@@ -1898,6 +1898,16 @@ describe('$file pkg', function() {
               expect($file.yaml.get(testFile, field)).to.be.eql(expected);
             });
           });
+          it('Accesses arrays by index', function() {
+            const testFile = s.normalize('sample_dir/properties.yaml');
+
+            _.each({
+              'list2[0]': 'item3',
+              'list2[1]': 'item4',
+            }, function(expected, field) {
+              expect($file.yaml.get(testFile, field)).to.be.eql(expected);
+            });
+          });
         });
         describe('#set()', function() {
           it('Adds parameter to root', function() {


### PR DESCRIPTION
It was not supported to retrieve an element inside an array in a yaml.

This makes `/builds[1]` retrieve the second element (`second`) in this yaml:

```
builds:
  - first
  - second
```