### PR TITLE
Update dependencies to use HTTPS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nami-utils",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2652,8 +2652,8 @@
       "dev": true
     },
     "eslint-config-bitnami": {
-      "version": "github:bitnami/eslint-config-bitnami#076726d915dd6757dd26657a8ef304924dc6d66f",
-      "from": "github:bitnami/eslint-config-bitnami#v1.0.0",
+      "version": "git+https://git@github.com/bitnami/eslint-config-bitnami.git#076726d915dd6757dd26657a8ef304924dc6d66f",
+      "from": "git+https://git@github.com/bitnami/eslint-config-bitnami.git#v1.0.0",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^3.0.1"
@@ -6824,12 +6824,12 @@
       "dev": true
     },
     "nami-test": {
-      "version": "github:bitnami/nami-test#7804afc44358e0cc1c5e3a7b5895d53ac29226df",
-      "from": "github:bitnami/nami-test#v1.0.1",
+      "version": "git+https://git@github.com/bitnami/nami-test.git#ed10ac9d509e89e889aec4c6e18aaad1689dd3d2",
+      "from": "git+https://git@github.com/bitnami/nami-test.git#v1.0.3",
       "dev": true,
       "requires": {
         "fs-extra": "^0.30.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "tmp": "^0.0.28"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nami-utils",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Utility functions for Nami",
   "repository": {
     "type": "git",
@@ -39,11 +39,11 @@
     "chai": "^3.5.0",
     "chai-fs": "^1.0.0",
     "eslint": "^6.5.1",
-    "eslint-config-bitnami": "github:bitnami/eslint-config-bitnami#v1.0.0",
+    "eslint-config-bitnami": "git+https://git@github.com/bitnami/eslint-config-bitnami#v1.0.0",
     "eslint-plugin-import": "^1.14.0",
     "gulp": "^4.0.2",
     "gulp4-run-sequence": "^1.0.1",
-    "nami-test": "github:bitnami/nami-test#v1.0.1",
+    "nami-test": "git+https://git@github.com/bitnami/nami-test#v1.0.3",
     "tmp": "0.0.28"
   }
 }


### PR DESCRIPTION
To our internal CIs execution times, we will update those dependencies downloaded from GitHub to use HTTPS (443) instead of git (9418). When possible, also updates the dependencies to the version using HTTPS as well.

The dependency of `bitnami-gulp-common-tasks` won't be updated to use HTTPS. There has been an update in the `mocha` sub-dependency that breaks compatibility with Node.js 8, making `bitnami-gulp-common-tasks@3.x` affected.

A major revision on the dependencies would be needed, probably using fixed versions compatible with Node 8. It has been decided to leave that dependency as it, without applying any changes to `bitnami-gulp-common-tasks` dependencies, until Node 8 support for Nami is dropped given the non-critical priority updating `bitnami-gulp-common-tasks` currently has.
